### PR TITLE
Support fedora and rhel7 based containers in osbs-box.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 certs/
+client/Dockerfile
+hub/Dockerfile
+koji-builder/Dockerfile
+shared-data/Dockerfile

--- a/client/Dockerfile.fedora
+++ b/client/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM fedora:25
+FROM fedora:26
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
 ARG UPDATES

--- a/client/Dockerfile.rhel7
+++ b/client/Dockerfile.rhel7
@@ -1,0 +1,21 @@
+FROM rhel7:latest
+MAINTAINER Luiz Carvalho <lucarval@redhat.com>
+
+ARG REPO_URL
+ARG UPDATES
+
+ADD ${REPO_URL} /etc/yum.repos.d/internal.repo
+RUN if [ $UPDATES ]; then yum update -y; fi && \
+    yum install -y \
+      openshift-clients \
+      iproute \
+      koji-containerbuild-cli \
+    && yum clean all
+
+ADD bin/ /usr/local/bin/
+ADD configs/ /configs
+
+RUN chmod +x /usr/local/bin/*
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/client/bin/setup.sh
+++ b/client/bin/setup.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 set -xeuo pipefail
 
+# Koji CLI in RHEL7 has a nasty bug - it attempts to verify that user is 
+# package owner before auth procedure
+# Lets quickly patch it
+
+sed -i "s;if not options\.owner;activate_session(session)\n    if not options\.owner;" /usr/bin/koji
+sed -i -e '701d;' /usr/bin/koji
+
 # TODO: Just create directly in DB?
 koji add-tag build --arches=x86_64
 koji add-tag dest --arches=x86_64
 koji add-target candidate build dest
 
+#sleep infinity
 koji add-pkg dest osbs-buildroot-docker --owner kojiadmin
 koji add-pkg dest docker-hello-world --owner kojiadmin
 

--- a/hub/Dockerfile.fedora
+++ b/hub/Dockerfile.fedora
@@ -1,15 +1,7 @@
-FROM fedora:25
+FROM fedora:26
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
-VOLUME [\
-    "/opt/osbs", \
-    "/opt/koji-clients", \
-    "/etc/pki/koji", \
-    "/certs", \
-    "/auth"\
-]
-
-EXPOSE 80
+EXPOSE 80 443
 
 ARG UPDATES
 ARG UPDATES_TESTING
@@ -20,19 +12,24 @@ RUN if [ $UPDATES ]; then dnf update -y; fi && \
             dnf config-manager --set-enable updates-testing &&\
             dnf -y update; fi && \
     dnf -y install \
-        openssl \
         hostname \
         httpd \
-        httpd-tools \
+        koji-containerbuild-hub \
+        koji-hub \
+        koji-hub-plugins \
+        koji-utils \
+        koji-web \
+        mod_auth_kerb \
+        mod_ssl \
+        mod_wsgi \
     && dnf clean all
 
-ADD opt/ /opt/
-ADD etc/ /etc/
-ADD bin/ /usr/local/bin/
-ADD root/ /root/
+COPY etc/ /etc/
+COPY bin/ /usr/local/bin/
 
-RUN ls -l /usr/local/bin
-RUN /usr/local/bin/setup.sh
+RUN chmod +x /usr/local/bin/* && \
+    mkdir -p /mnt/koji/{packages,repos,work,scratch} && \
+    chown apache.apache /mnt/koji/*
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["httpd", "-D", "FOREGROUND"]

--- a/hub/Dockerfile.rhel7
+++ b/hub/Dockerfile.rhel7
@@ -1,17 +1,14 @@
-FROM fedora:25
+FROM rhel7:latest
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
 EXPOSE 80 443
 
+ARG REPO_URL
 ARG UPDATES
-ARG UPDATES_TESTING
 
-RUN if [ $UPDATES ]; then dnf update -y; fi && \
-    if [ $UPDATES_TESTING ]; then \
-            dnf install -y dnf-plugins-core && \
-            dnf config-manager --set-enable updates-testing &&\
-            dnf -y update; fi && \
-    dnf -y install \
+ADD ${REPO_URL} /etc/yum.repos.d/internal.repo
+RUN if [ $UPDATES ]; then yum update -y; fi && \
+    yum install -y \
         hostname \
         httpd \
         koji-containerbuild-hub \
@@ -22,7 +19,7 @@ RUN if [ $UPDATES ]; then dnf update -y; fi && \
         mod_auth_kerb \
         mod_ssl \
         mod_wsgi \
-    && dnf clean all
+    && yum clean all
 
 COPY etc/ /etc/
 COPY bin/ /usr/local/bin/

--- a/koji-builder/Dockerfile.fedora
+++ b/koji-builder/Dockerfile.fedora
@@ -1,0 +1,27 @@
+FROM fedora:26
+MAINTAINER Luiz Carvalho <lucarval@redhat.com>
+
+ARG UPDATES
+ARG UPDATES_TESTING
+
+RUN if [ $UPDATES ]; then dnf update -y; fi && \
+    if [ $UPDATES_TESTING ]; then \
+            dnf install -y dnf-plugins-core && \
+            dnf config-manager --set-enable updates-testing &&\
+            dnf -y update; fi && \
+    dnf -y install \
+        mock \
+        koji-builder \
+        koji-containerbuild-builder \
+        osbs-client \
+        python-osbs-client \
+        python-pip \
+        findutils \
+    && dnf clean all
+
+ADD etc/ /etc/
+ADD bin/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/*
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/usr/sbin/init"]

--- a/koji-builder/Dockerfile.rhel7
+++ b/koji-builder/Dockerfile.rhel7
@@ -1,0 +1,25 @@
+FROM rhel7:latest
+MAINTAINER Luiz Carvalho <lucarval@redhat.com>
+
+ARG REPO_URL
+ARG UPDATES
+
+ADD ${REPO_URL} /etc/yum.repos.d/internal.repo
+RUN if [ $UPDATES ]; then yum update -y; fi && \
+    yum install -y \
+        mock \
+        koji-builder \
+        koji-containerbuild-builder \
+        osbs-client \
+        python-osbs-client \
+        python-hashlib \
+        python-pip \
+        findutils \
+    && yum clean all
+
+ADD etc/ /etc/
+ADD bin/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/*
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/usr/sbin/init"]

--- a/shared-data/Dockerfile.fedora
+++ b/shared-data/Dockerfile.fedora
@@ -1,5 +1,15 @@
-FROM fedora:25
+FROM fedora:26
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
+
+VOLUME [\
+    "/opt/osbs", \
+    "/opt/koji-clients", \
+    "/etc/pki/koji", \
+    "/certs", \
+    "/auth"\
+]
+
+EXPOSE 80
 
 ARG UPDATES
 ARG UPDATES_TESTING
@@ -10,19 +20,19 @@ RUN if [ $UPDATES ]; then dnf update -y; fi && \
             dnf config-manager --set-enable updates-testing &&\
             dnf -y update; fi && \
     dnf -y install \
-        mock \
-        koji-builder \
-        koji-containerbuild-builder \
-        osbs-client \
-        python-osbs-client \
-        python-hashlib \
-        python-pip \
-        findutils \
+        openssl \
+        hostname \
+        httpd \
+        httpd-tools \
     && dnf clean all
 
+ADD opt/ /opt/
 ADD etc/ /etc/
 ADD bin/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/*
+ADD root/ /root/
+
+RUN ls -l /usr/local/bin
+RUN /usr/local/bin/setup.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["/usr/sbin/init"]
+CMD ["httpd", "-D", "FOREGROUND"]

--- a/shared-data/Dockerfile.rhel7
+++ b/shared-data/Dockerfile.rhel7
@@ -1,0 +1,35 @@
+FROM rhel7:latest
+MAINTAINER Luiz Carvalho <lucarval@redhat.com>
+
+VOLUME [\
+    "/opt/osbs", \
+    "/opt/koji-clients", \
+    "/etc/pki/koji", \
+    "/certs", \
+    "/auth"\
+]
+
+EXPOSE 80
+
+ARG REPO_URL
+ARG UPDATES
+
+ADD ${REPO_URL} /etc/yum.repos.d/internal.repo
+RUN if [ $UPDATES ]; then yum update -y; fi && \
+    yum -y install \
+        openssl \
+        hostname \
+        httpd \
+        httpd-tools \
+    && yum clean all
+
+ADD opt/ /opt/
+ADD etc/ /etc/
+ADD bin/ /usr/local/bin/
+ADD root/ /root/
+
+RUN ls -l /usr/local/bin
+RUN /usr/local/bin/setup.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["httpd", "-D", "FOREGROUND"]


### PR DESCRIPTION
This adds two new params for osbs-box.py:
* `--distro` - it determines which Dockerfile to use. 

By default `rhel7` and `fedora` (latest stable, F26) are provided
More specific dockerfiles - e.g. `fedora26-py3` - are possible.
* `--repo-url` - a URL to the repo file with repos for RHEL images.

RHEL7 images fail to start due to certificate error when connecting to koji-hub

UPD. This is probably a bug in rhel7's koji cli - in `add-pkg` it tries to identify if owner is actually a user before setting up params for connection. As a result it doesn't pass the certificate and fails. `setup.sh` will patch the koji cli on the client for now.