### PR TITLE
Create policybinding via yaml as RHEL7's oc is outdated

### DIFF
--- a/client/bin/setup.sh
+++ b/client/bin/setup.sh
@@ -33,7 +33,17 @@ oc secret new kojisecret \
 
 oc secrets add serviceaccount/builder secrets/kojisecret --for=mount
 
-oc create policybinding osbs
+# RHEL 7 has outdated oc, so use a fallback method
+#oc create policybinding osbs
+oc create -f - << EOF
+apiVersion: v1
+kind: PolicyBinding
+metadata:
+  name: osbs:default
+policyRef:
+  name: default
+  namespace: osbs
+EOF
 
 oc create -f - << EOF
 apiVersion: v1
@@ -61,7 +71,17 @@ oc secret new kojisecret \
 
 oc secrets add serviceaccount/builder secrets/kojisecret --for=mount
 
-oc create policybinding worker
+# RHEL 7 has outdated oc, so use a fallback method
+#oc create policybinding worer
+oc create -f - << EOF
+apiVersion: v1
+kind: PolicyBinding
+metadata:
+  name: worker:default
+policyRef:
+  name: default
+  namespace: worker
+EOF
 
 oc create -f - << EOF
 apiVersion: v1


### PR DESCRIPTION
Otherwise RHEL7-based box fails with:
```
++ oc secrets add serviceaccount/builder secrets/kojisecret --for=mount
++ oc create policybinding osbs
Create a resource by filename or stdin
JSON and YAML formats are accepted.
Usage:
  oc create -f FILENAME [options]
Examples:
  # Create a pod using the data in pod.json.
  $ oc create -f pod.json
  # Create a pod based on the JSON passed into stdin.
  $ cat pod.json | oc create -f -
Available Commands:
  namespace      Create a namespace with the specified name.
  secret         Create a secret using specified subcommand.
  serviceaccount Create a service account with the specified name.
  route          Expose containers externally via secured routes
Options:
  -f, --filename=[]: Filename, directory, or URL to file to use to create the resource
  -o, --output='': Output mode. Use "-o name" for shorter output (resource/name).
      --record=false: Record current kubectl command in the resource annotation.
      --save-config=false: If true, the configuration of current object will be saved in its annotation. This is useful when you want to perform kubectl apply on this object in the future.
      --schema-cache-dir='~/.kube/schema': If non-empty, load/store cached API schemas in this directory, default is '$HOME/.kube/schema'
      --validate=false: If true, use a schema to validate the input before sending it
Use "oc help <command>" for more information about a given command.
Use "oc options" for a list of global command-line options (applies to all commands).
++ oc create -f -
role "osbs-custom-build" created
++ oc adm policy add-role-to-user osbs-custom-build osbs -z builder --role-namespace osbs
Error from server: policybindings "osbs:default" not found
```