### PR TITLE
Registry certs: add external IP via extfile.cnf

### DIFF
--- a/shared-data/bin/setup.sh
+++ b/shared-data/bin/setup.sh
@@ -43,10 +43,12 @@ mkdir -p /root/.koji
 ln -s /opt/local/koji-clients/kojiadmin/config /root/.koji/config
 
 # Generate certificates and set password for registry
+cat /opt/local/pki/koji/ssl.cnf | sed "s/email\:move/IP:172.17.0.1,email:move/"> ssl.cnf
 mkdir /opt/local/certs
-openssl req \
+openssl req -config ssl.cnf \
     -subj "/C=US/ST=Drunken/L=Bed/O=IT/CN=172.17.0.1" \
     -newkey rsa:4096 -nodes -sha256 -keyout /opt/local/certs/domain.key \
-    -x509 -days 365 -out /opt/local/certs/domain.crt
+    -x509 -days 365 -out /opt/local/certs/domain.crt \
+    -extensions v3_ca
 mkdir /opt/local/auth
 htpasswd -Bbn osbs craycray > /opt/local/auth/htpasswd


### PR DESCRIPTION
For some reason a simple `CN=<host IP>` was causing issues for @csomh. This adds the IP address again to SAN list