### PR TITLE
Relabel certs when mounting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
             - osbsbox-koji-config:/opt/koji-clients
             - osbsbox-koji-certs:/etc/pki/koji
             - osbsbox-registry-auth:/auth
-            - ./certs:/certs
+            - ./certs:/certs:z
 
     koji-db:
         build: koji-db


### PR DESCRIPTION
This makes SELinux happy when containers try to write to this
volume.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>