### PR TITLE
Install updates only when --updates option is specified

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,11 +1,14 @@
 FROM fedora:25
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
+ARG UPDATES
 ARG UPDATES_TESTING
 
-RUN dnf update -y && dnf install -y dnf-plugins-core && \
-    if [ $UPDATES_TESTING ]; then dnf config-manager --set-enable updates-testing; fi && \
-    dnf -y update && \
+RUN if [ $UPDATES ]; then dnf update -y; fi && \
+    if [ $UPDATES_TESTING ]; then \
+            dnf install -y dnf-plugins-core && \
+            dnf config-manager --set-enable updates-testing &&\
+            dnf -y update; fi && \
     dnf install -y \
       origin-clients \
       iproute \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     shared-data:
         build:
           context: shared-data
-          args:
-            UPDATES_TESTING: 1
+        # Uncomment to use packages from updates-testing repo
+        #   args:
+        #     UPDATES_TESTING: 1
         hostname: shared-data
         volumes:
             - osbsbox-osbs:/opt/osbs
@@ -32,8 +33,9 @@ services:
     koji-hub:
         build:
           context: hub
-          args:
-            UPDATES_TESTING: 1
+        # Uncomment to use packages from updates-testing repo
+        #   args:
+        #     UPDATES_TESTING: 1
         hostname: koji-hub
         volumes_from:
             - shared-data
@@ -46,8 +48,9 @@ services:
     koji-builder:
         build:
           context: koji-builder
-          args:
-            UPDATES_TESTING: 1
+        # Uncomment to use packages from updates-testing repo
+        #   args:
+        #     UPDATES_TESTING: 1
         hostname: koji-builder
         volumes_from:
             - shared-data
@@ -60,8 +63,9 @@ services:
     koji-client:
         build:
           context: client
-          args:
-            UPDATES_TESTING: 1
+        # Uncomment to use packages from updates-testing repo
+        #   args:
+        #     UPDATES_TESTING: 1
         hostname: koji-client
         volumes_from:
             - shared-data

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -3,11 +3,14 @@ MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
 EXPOSE 80 443
 
+ARG UPDATES
 ARG UPDATES_TESTING
 
-RUN dnf update -y && dnf install -y dnf-plugins-core && \
-    if [ $UPDATES_TESTING ]; then dnf config-manager --set-enable updates-testing; fi && \
-    dnf -y update && \
+RUN if [ $UPDATES ]; then dnf update -y; fi && \
+    if [ $UPDATES_TESTING ]; then \
+            dnf install -y dnf-plugins-core && \
+            dnf config-manager --set-enable updates-testing &&\
+            dnf -y update; fi && \
     dnf -y install \
         hostname \
         httpd \

--- a/koji-builder/Dockerfile
+++ b/koji-builder/Dockerfile
@@ -1,12 +1,15 @@
 FROM fedora:25
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
+ARG UPDATES
 ARG UPDATES_TESTING
 
-RUN dnf update -y && dnf install -y dnf-plugins-core && \
-    if [ $UPDATES_TESTING ]; then dnf config-manager --set-enable updates-testing; fi && \
-    dnf -y update && \
-    dnf -y install --nogpgcheck \
+RUN if [ $UPDATES ]; then dnf update -y; fi && \
+    if [ $UPDATES_TESTING ]; then \
+            dnf install -y dnf-plugins-core && \
+            dnf config-manager --set-enable updates-testing &&\
+            dnf -y update; fi && \
+    dnf -y install \
         mock \
         koji-builder \
         koji-containerbuild-builder \

--- a/osbs-box.py
+++ b/osbs-box.py
@@ -101,7 +101,11 @@ def up(args):
     cmd = ["docker-compose", "build"]
     if args.force_rebuild:
         cmd += ["--no-cache"]
-    _run(cmd)
+    if args.updates:
+        cmd += ["--build-arg", "UPDATES=1"]
+
+    for service in ['shared-data', 'koji-hub', 'koji-builder', 'koji-client']:
+        _run(cmd + [service])
 
     # Start docker-compose
     cmd = ["docker-compose", "up", "-d"]
@@ -170,6 +174,9 @@ if __name__ == "__main__":
         "--force-rebuild", action="store_true",
         help="Force image rebuild"
     )
+    parse_up.add_argument(
+        "--updates", action="store_true",
+        help="Update packages")
 
     parsed = parser.parse_args()
     parsed.func(parsed)

--- a/shared-data/Dockerfile
+++ b/shared-data/Dockerfile
@@ -11,11 +11,14 @@ VOLUME [\
 
 EXPOSE 80
 
+ARG UPDATES
 ARG UPDATES_TESTING
 
-RUN dnf update -y && dnf install -y dnf-plugins-core && \
-    if [ $UPDATES_TESTING ]; then dnf config-manager --set-enable updates-testing; fi && \
-    dnf -y update && \
+RUN if [ $UPDATES ]; then dnf update -y; fi && \
+    if [ $UPDATES_TESTING ]; then \
+            dnf install -y dnf-plugins-core && \
+            dnf config-manager --set-enable updates-testing &&\
+            dnf -y update; fi && \
     dnf -y install \
         openssl \
         hostname \


### PR DESCRIPTION
Updates-testing repo is enabled in docker-compose.yml via build args.

It seems to build faster from scratch - ~3 min vs. ~9 mins. After the latyers 
are cached the time to build the images is approx. the same - around a minute 
and a half (due to setting up a new cluster mostly).

Fixes #21