### PR TITLE
Run koji-builder container in privileged mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     koji-builder:
         build:
           context: koji-builder
+        privileged: true
         hostname: koji-builder
         volumes_from:
             - shared-data


### PR DESCRIPTION
This is to allow systemd to work properly.

Fixes #30