### PR TITLE
Specify official registry for rhel7:latest

### DIFF
--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7:latest
+FROM registry.access.redhat.com/rhel7:latest
 MAINTAINER Luiz Carvalho <lucarval@redhat.com>
 
 ARG REPO_URL


### PR DESCRIPTION
Pull rhel7 image from official RedHat registry.