### PR TITLE
Update example build commands to use branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ python ./osbs-box up --distro rhel7 --repo-url=...
 ```
 # On client container
 koji-containerbuild container-build candidate \
-    git://github.com/lcarva/docker-hello-world#3ddf64777f335788145a097dee8a14ea0d494742
+    git://github.com/lcarva/docker-hello-world#origin/osbs-box-demo \
+    --git-branch osbs-box-demo
 
 # Or from the host (useful for retaining bash history between runs)
 docker exec -it osbsbox_koji-client_1 koji-containerbuild container-build candidate \
-    git://github.com/lcarva/docker-hello-world#3ddf64777f335788145a097dee8a14ea0d494742
+    git://github.com/lcarva/docker-hello-world#origin/osbs-box-demo \
+    --git-branch osbs-box-demo
 ```
 
 ## Containers


### PR DESCRIPTION
git-branch is now required for the container-build command.
Also, using a origin/<branch> instead of commit ID for
flexibility.