### PR TITLE
Add koji-steal-build script

### DIFF
--- a/hub/Dockerfile.fedora
+++ b/hub/Dockerfile.fedora
@@ -13,6 +13,7 @@ RUN dnf -y --refresh install \
         mod_auth_kerb \
         mod_ssl \
         mod_wsgi \
+        python-requests \
     && dnf clean all
 
 COPY etc/ /etc/

--- a/hub/Dockerfile.rhel7
+++ b/hub/Dockerfile.rhel7
@@ -13,6 +13,7 @@ RUN yum install -y \
         mod_auth_kerb \
         mod_ssl \
         mod_wsgi \
+        python-requests \
     && yum clean all
 
 COPY etc/ /etc/

--- a/hub/bin/koji-steal-build
+++ b/hub/bin/koji-steal-build
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+import argparse
+import koji
+import os
+import requests
+import subprocess
+import hashlib
+
+
+DEFAULT_DOWNLOAD_BLOCK_SIZE = 10 * 1024 * 1024  # 10Mb
+
+
+class BuildStealer(object):
+
+    def __init__(self, nvr, kojihub, kojiroot):
+        self.nvr = nvr
+        self.pathinfo = koji.PathInfo(topdir=kojiroot)
+        self.session = koji.ClientSession(kojihub)
+
+        self.output_dir = os.path.join('/mnt/koji/work/build-stealer', nvr)
+
+        self.build_info = None
+        self.build_metadata = None
+        self.build_metadata_url = None
+
+    def start(self):
+        self.get_build_info()
+        self.get_build_metadata()
+        self.download_build_files()
+        self.import_build()
+
+    def get_build_info(self):
+        self.build_info = self.session.getBuild(self.nvr, strict=True)
+
+    def get_build_metadata(self):
+        self.build_metadata_url = os.path.join(self.pathinfo.build(self.build_info),
+                                               'metadata.json')
+        response = requests.get(self.build_metadata_url)
+        response.raise_for_status()
+        self.build_metadata = response.json()
+
+    def download_build_files(self):
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+
+        for output in self.build_metadata['output']:
+            url, dest = self._resolve_file_download(output)
+            print('Downloading {}'.format(output['filename']))
+            self._download_file(url, dest, output['checksum'])
+
+    def _resolve_file_download(self, output):
+        dest_path = os.path.join(self.output_dir, output['filename'])
+
+        url_bases = {
+            'log': self.pathinfo.build_logs,
+            'docker-image': self.pathinfo.imagebuild,
+        }
+        url_base = url_bases[output['type']](self.build_info)
+        url = os.path.join(url_base, output['filename'])
+
+        return (url, dest_path)
+
+    def import_build(self):
+        metadata_filename = 'metadata-{}.json'.format(self.nvr)
+        metadata_path = os.path.join(self.output_dir, metadata_filename)
+        self._download_file(self.build_metadata_url, metadata_path)
+
+        # TODO: Create a new koji session with local defaults instead of calling koji process.
+        print('Importing build {}'.format(metadata_filename))
+        subprocess.call(['koji', 'import-cg', '--link', metadata_path, self.output_dir])
+
+        # TODO: For some reason the logs don't appear in final build.
+
+    def _download_file(self, url, dest, expected_checksum=None):
+        checksum = hashlib.md5()
+        request = requests.get(url, stream=True)
+        request.raise_for_status()
+
+        with open(dest, 'wb') as f:
+            for chunk in request.iter_content(chunk_size=DEFAULT_DOWNLOAD_BLOCK_SIZE):
+                f.write(chunk)
+                checksum.update(chunk)
+
+        if expected_checksum and checksum.hexdigest() != expected_checksum:
+            raise ValueError(
+                'Computed md5 checksum, {}, does not match expected checksum, {}'
+                .format(checksum.hexdigest(), expected_checksum))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Take a build from another Koji instance and load it here.")
+
+    parser.add_argument('nvr', help='Name-Version-Release of build to be moved')
+    parser.add_argument('--kojihub', required=True, help='Koji Hub API to pull build from')
+    parser.add_argument('--kojiroot', required=True, help='Koji Top Dir to pull build from')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    BuildStealer(args.nvr, args.kojihub, args.kojiroot).start()


### PR DESCRIPTION
This script is deployed inside the koji-hub container which
can then be used to "steal" a build from another Koji instance
and import it into the Koji instance in osbs-box.