### PR TITLE
Install atomic-openshift-clients package correctly

### DIFF
--- a/client/Dockerfile.rhel7
+++ b/client/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM osbs-box:rhel7
 
 RUN yum install -y \
-      openshift-clients \
+      atomic-openshift-clients \
       iproute \
       koji-containerbuild-cli \
     && yum clean all


### PR DESCRIPTION
At some point the package openshift-clients was renamed to
atomic-openshift-clients. The older name still works, but
it's forever stuck in a time where some functionality, such
as creating policybindings, did not exist.