### PR TITLE
Token expiration

### DIFF
--- a/client/bin/entrypoint.sh
+++ b/client/bin/entrypoint.sh
@@ -24,8 +24,6 @@ ln -fs /opt/osbs/osbs.conf /etc/osbs.conf
 # For accessing containers not part of the default network
 WORKSTATION_IP=$(/sbin/ip route | awk '/default/ { print $3 }')
 oc login --insecure-skip-tls-verify=true -u osbs -p osbs https://${WORKSTATION_IP}:8443/
-token=$(oc whoami -t)
-sed --follow-symlinks -i "s/OSBS_TOKEN/${token}/" /etc/osbs.conf
 # Use workstation's IP so it's reachable from within openshift's pods
 sed --follow-symlinks -i "s/KOJI_HUB_IP/${WORKSTATION_IP}/" /etc/osbs.conf
 sed --follow-symlinks -i "s/OPENSHIFT_IP/${WORKSTATION_IP}/" /etc/osbs.conf

--- a/client/bin/setup.sh
+++ b/client/bin/setup.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# Koji CLI in RHEL7 has a nasty bug - it attempts to verify that user is 
-# package owner before auth procedure
-# Lets quickly patch it
-
-sed -i "s;if not options\.owner;activate_session(session)\n    if not options\.owner;" /usr/bin/koji
-sed -i -e '701d;' /usr/bin/koji
-
 # TODO: Just create directly in DB?
 koji add-tag build --arches=x86_64
 koji add-tag dest --arches=x86_64
 koji add-target candidate build dest
 
-#sleep infinity
 koji add-pkg dest osbs-buildroot-docker --owner kojiadmin
 koji add-pkg dest docker-hello-world --owner kojiadmin
 

--- a/client/bin/setup.sh
+++ b/client/bin/setup.sh
@@ -87,11 +87,8 @@ oc adm policy add-role-to-user osbs-custom-build osbs -z builder --role-namespac
 
 oc secrets new-dockercfg v2-registry-dockercfg --docker-server=172.17.0.1:5000 --docker-username=osbs --docker-password=craycray --docker-email=test@test.com
 
-token=$(oc whoami -t)
-
 cp /configs/reactor-config-secret.yml /tmp/config.yaml
 cp /configs/client-config-secret.conf /tmp/osbs.conf
-sed -i "s/OSBS_TOKEN/${token}/" /tmp/osbs.conf
 sed -i "s/KOJI_HUB_IP/${WORKSTATION_IP}/" /tmp/osbs.conf
 
 oc project osbs

--- a/client/configs/client-config-secret.conf
+++ b/client/configs/client-config-secret.conf
@@ -15,4 +15,5 @@ registry_uri = https://172.17.0.1:5000/v2
 use_auth = true
 use_kerberos = false
 verify_ssl = false
-token = OSBS_TOKEN
+username = osbs
+password = osbs

--- a/shared-data/opt/local/osbs/osbs.conf
+++ b/shared-data/opt/local/osbs/osbs.conf
@@ -26,10 +26,11 @@ use_auth = true
 use_kerberos = false
 vendor = Red Hat, Inc.
 verify_ssl = false
-token = OSBS_TOKEN
 client_config_secret = client-config-secret
 reactor_config_secret = reactor-config-secret
 can_orchestrate = true
+username = osbs
+password = osbs
 
 [scratch]
 authoritative_registry = registry.fedoraproject.org
@@ -50,8 +51,9 @@ use_auth = true
 use_kerberos = false
 vendor = Red Hat, Inc.
 verify_ssl = false
-token = OSBS_TOKEN
 client_config_secret = client-config-secret
 reactor_config_secret = reactor-config-secret
 can_orchestrate = true
 scratch = True
+username = osbs
+password = osbs


### PR DESCRIPTION
Two commits:

Workaround for #52 until we get around to setting up a proper service account.
```
Use username/password for OpenShift auth
```

and removal of support for older koji version (<= 1.10)
```
Remove workaround for older koji version 
```