### PR TITLE
Allow koji-client to access docker socket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,9 @@ services:
         build:
           context: client
         hostname: koji-client
+        privileged: true
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
         volumes_from:
             - shared-data
 


### PR DESCRIPTION
This is required to run integration tests in container