### PR TITLE
Fix certificate errors when accessing koji-hub

### DIFF
--- a/client/bin/entrypoint.sh
+++ b/client/bin/entrypoint.sh
@@ -21,8 +21,8 @@ then
 fi
 
 ln -fs /opt/osbs/osbs.conf /etc/osbs.conf
-# For accessing containers not part of the default network
-WORKSTATION_IP=$(/sbin/ip route | awk '/default/ { print $3 }')
+# For accessing containers from outside the default network
+WORKSTATION_IP='172.17.0.1'
 oc login --insecure-skip-tls-verify=true -u osbs -p osbs https://${WORKSTATION_IP}:8443/
 # Use workstation's IP so it's reachable from within openshift's pods
 sed --follow-symlinks -i "s/KOJI_HUB_IP/${WORKSTATION_IP}/" /etc/osbs.conf

--- a/client/bin/setup.sh
+++ b/client/bin/setup.sh
@@ -13,7 +13,7 @@ koji add-pkg dest docker-hello-world --owner kojiadmin
 koji grant_cg_access kojiosbs atomic-reactor
 # TODO: Create a channel
 
-WORKSTATION_IP=$(/sbin/ip route | awk '/default/ { print $3 }')
+WORKSTATION_IP='172.17.0.1'
 oc login --insecure-skip-tls-verify=true -u osbs -p osbs https://${WORKSTATION_IP}:8443/
 # Some of the commands below require user to be a cluster admin
 # In the future, this project should provide an ansible playbook

--- a/shared-data/bin/setup.sh
+++ b/shared-data/bin/setup.sh
@@ -21,6 +21,7 @@ conf=confs/ca.cnf
 cp ssl.cnf $conf
 
 openssl genrsa -out private/koji_ca_cert.key 2048
+sed -i "s/email\:move/DNS.1:koji-hub,DNS.2:172.17.0.1/" $conf
 openssl req -config $conf -new -x509 \
     -subj "/C=US/ST=Drunken/L=Bed/O=IT/CN=koji-hub" \
     -days 3650 \


### PR DESCRIPTION
During a build, koji-hub is accessed from outside the
default network created by docker-compose. For this reason
the hostname "koji-hub" does not resolve as expected. The
alternative is to access koji-hub by its IP address, which
has worked in the past. However, due to newer koji versions
certificate verification is stronger, requiring the IP address
to also be list in koji-hub's identity certificate.

For simplicity the special IP address 172.17.0.1 is used for
certificate generation. This IP has shown to be consistent
across different hosts (container registry is already accessed
this way).