### PR TITLE
hub: Limit HTTP workers to avoid exhausting postgres connections

### DIFF
--- a/hub/etc/httpd/conf.d/max-requests.conf
+++ b/hub/etc/httpd/conf.d/max-requests.conf
@@ -1,0 +1,4 @@
+# Keep number of workers/threads low to avoid exhausting postgres connections
+# This should work for both prefork (RHEL 7) and event (Fedora) MPMs
+MaxRequestWorkers 40
+ThreadsPerChild 10


### PR DESCRIPTION
The default value of MaxRequestWorkers is 256, while postgres in our
configuration only allows about 100 simulataneous connections. The
koji code ends up caching a DB connection per worker process/thread,
So the DB runs out of connections after enough requests to Koji.
40 simultaneous connections to the Koji hub should be plenty for
anything we do.