### PR TITLE
Share /mnt/koji

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
     osbsbox-osbs:
     osbsbox-koji-config:
     osbsbox-registry-auth:
+    osbsbox-koji-data:
 
 services:
 
@@ -13,6 +14,7 @@ services:
         hostname: shared-data
         volumes:
             - osbsbox-osbs:/opt/osbs
+            - osbsbox-koji-data:/mnt/koji
             - osbsbox-koji-config:/opt/koji-clients
             - osbsbox-registry-auth:/auth
             - ./ssl:/etc/pki/osbs-box:z

--- a/koji-builder/etc/kojid/kojid.conf
+++ b/koji-builder/etc/kojid/kojid.conf
@@ -1,8 +1,8 @@
 [kojid]
 server=https://koji-hub:8083/kojihub
 topurl=http://koji-hub/kojifiles
-workdir=/tmp/koji
-topdir=/tmp/koji
+workdir=/mnt/koji
+topdir=/mnt/koji
 cert = /etc/pki/osbs-box/certs/kojibuilder.crt
 ca = /etc/pki/osbs-box/certs/koji_ca_cert.crt
 serverca = /etc/pki/osbs-box/certs/koji_ca_cert.crt

--- a/shared-data/Dockerfile.fedora
+++ b/shared-data/Dockerfile.fedora
@@ -21,6 +21,8 @@ ADD etc/ /etc/
 ADD bin/ /usr/local/bin/
 ADD root/ /root/
 
+RUN mkdir -p /mnt/koji/{packages,repos,work,scratch,composes} && chown -R apache:apache /mnt/koji
+
 RUN ls -l /usr/local/bin
 RUN /usr/local/bin/setup.sh
 

--- a/shared-data/Dockerfile.rhel7
+++ b/shared-data/Dockerfile.rhel7
@@ -21,6 +21,8 @@ ADD etc/ /etc/
 ADD bin/ /usr/local/bin/
 ADD root/ /root/
 
+RUN mkdir -p /mnt/koji/{packages,repos,work,scratch,composes} && chown -R apache:apache /mnt/koji
+
 RUN ls -l /usr/local/bin
 RUN /usr/local/bin/setup.sh
 


### PR DESCRIPTION
In order to build packages, we need to create /mnt/koji with the right
structure and share it between the koji hub and builder.

(Building packages is needed for Flatpak testing, since the application packages get rebuilt with prefix=/app)