### PR TITLE
Make pkgs.fedoraproject.org work

### DIFF
--- a/koji-builder/etc/kojid/kojid.conf
+++ b/koji-builder/etc/kojid/kojid.conf
@@ -8,5 +8,5 @@ ca = /etc/pki/osbs-box/certs/koji_ca_cert.crt
 serverca = /etc/pki/osbs-box/certs/koji_ca_cert.crt
 PluginPath = /usr/lib/koji-builder-plugins
 Plugins = builder_containerbuild
-allowed_scms=pkgs.fedoraproject.org:/*:no:fedpkg,sources *:/*:no
+allowed_scms=pkgs.fedoraproject.org:/*:no:--enable-network,fedpkg,sources *:/*:no
 minspace=10

--- a/koji-builder/etc/kojid/kojid.conf
+++ b/koji-builder/etc/kojid/kojid.conf
@@ -8,5 +8,5 @@ ca = /etc/pki/osbs-box/certs/koji_ca_cert.crt
 serverca = /etc/pki/osbs-box/certs/koji_ca_cert.crt
 PluginPath = /usr/lib/koji-builder-plugins
 Plugins = builder_containerbuild
-allowed_scms=*:/*:no
+allowed_scms=pkgs.fedoraproject.org:/*:no:fedpkg,sources *:/*:no
 minspace=10


### PR DESCRIPTION
To be able to build packages from pkgs.fedoraproject.org, the koji builder configuration needs to be changed to use fedpkg sources. But that fails with f27 mock due to lack of networking, so hack that --enable-networking to the mock command line when running 'fedpkg sources'.
