### PR TITLE
Remove ThreadsPerChild httpd setting

### DIFF
--- a/hub/etc/httpd/conf.d/max-requests.conf
+++ b/hub/etc/httpd/conf.d/max-requests.conf
@@ -1,4 +1,6 @@
 # Keep number of workers/threads low to avoid exhausting postgres connections
 # This should work for both prefork (RHEL 7) and event (Fedora) MPMs
 MaxRequestWorkers 40
+<IfModule mpm_event_module>
 ThreadsPerChild 10
+</IfModule>


### PR DESCRIPTION
This causes httpd to not start on RHEL 7.5

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>